### PR TITLE
chore: remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-04-08T08:50:29.720624381Z",
-  "version": "1.3.3",
+  "generated_at": "2026-05-29T13:54:41.010190481Z",
+  "version": "1.3.4",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/workflows/go-binaries.yml
+++ b/.github/workflows/go-binaries.yml
@@ -58,7 +58,7 @@ jobs:
           token: ${{ secrets.BOT_PAT_TOKEN }}
 
       - name: Update version tags
-        uses: cbrgm/semver-tag-sync-action@dc3fd41a0c5c35594c815757af016ea87eacca10 # v1.1.0
+        uses: cbrgm/semver-tag-sync-action@5c3ffb02969fa0e723f9b2b407955b950f37b883 # v1.1.1
         if: startsWith(github.ref, 'refs/tags/v')
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,7 @@ release-linux: $(DIST) \
 	$(DIST)/$(EXECUTABLE)_linux-arm-5 \
 	$(DIST)/$(EXECUTABLE)_linux-arm-6 \
 	$(DIST)/$(EXECUTABLE)_linux-arm-7 \
-	$(DIST)/$(EXECUTABLE)_linux-arm64 \
-	$(DIST)/$(EXECUTABLE)_linux-mips \
-	$(DIST)/$(EXECUTABLE)_linux-mips64 \
-	$(DIST)/$(EXECUTABLE)_linux-mipsle \
-	$(DIST)/$(EXECUTABLE)_linux-mips64le
+	$(DIST)/$(EXECUTABLE)_linux-arm64
 
 $(DIST)/$(EXECUTABLE)_linux-386:
 	GOOS=linux GOARCH=386 $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
@@ -132,17 +128,6 @@ $(DIST)/$(EXECUTABLE)_linux-arm-7:
 $(DIST)/$(EXECUTABLE)_linux-arm64:
 	GOOS=linux GOARCH=arm64 $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
 
-$(DIST)/$(EXECUTABLE)_linux-mips:
-	GOOS=linux GOARCH=mips $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
-
-$(DIST)/$(EXECUTABLE)_linux-mips64:
-	GOOS=linux GOARCH=mips64 $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
-
-$(DIST)/$(EXECUTABLE)_linux-mipsle:
-	GOOS=linux GOARCH=mipsle $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
-
-$(DIST)/$(EXECUTABLE)_linux-mips64le:
-	GOOS=linux GOARCH=mips64le $(GOBUILD) -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ ./cmd/$(NAME)
 
 .PHONY: release-darwin
 release-darwin: $(DIST) \


### PR DESCRIPTION
Remove linux/mips, linux/mips64, linux/mipsle, and linux/mips64le from release build targets.